### PR TITLE
Safer from blob

### DIFF
--- a/magick.go
+++ b/magick.go
@@ -58,6 +58,7 @@ MagickBooleanType CheckException(ExceptionInfo *exception)
   assert(exception->signature == MagickSignature);
   if (exception->exceptions  == (void *) NULL)
     return MagickFalse;
+
   LockSemaphoreInfo(exception->semaphore);
   ResetLinkedListIterator((LinkedListInfo *) exception->exceptions);
   p=(const ExceptionInfo *) GetNextValueInLinkedList((LinkedListInfo *)
@@ -133,6 +134,7 @@ Image *Negate(Image *image, ExceptionInfo *exception){
 */
 import "C"
 import (
+	"errors"
 	"os"
 	"strings"
 	"unsafe"
@@ -197,6 +199,7 @@ func NewFromBlob(blob []byte, extension string) (im *MagickImage, err error) {
 	defer C.DestroyExceptionInfo(exception)
 	info := C.AcquireImageInfo()
 	defer C.DestroyImageInfo(info)
+
 	c_filename := C.CString("image." + extension)
 	defer C.free(unsafe.Pointer(c_filename))
 	C.SetImageInfoFilename(info, c_filename)
@@ -214,9 +217,15 @@ func NewFromBlob(blob []byte, extension string) (im *MagickImage, err error) {
 	length := (C.size_t)(len(blob_copy))
 	blob_start := unsafe.Pointer(&blob_copy[0])
 	image := C.ReadImageFromBlob(info, blob_start, length)
+
+	if image == nil {
+		return nil, errors.New("CORRUPT IMAGE")
+	}
+
 	if failed := C.CheckException(exception); failed == C.MagickTrue {
 		return nil, ErrorFromExceptionInfo(exception)
 	}
+
 	return &MagickImage{image}, nil
 }
 

--- a/magick.go
+++ b/magick.go
@@ -134,7 +134,6 @@ Image *Negate(Image *image, ExceptionInfo *exception){
 */
 import "C"
 import (
-	"errors"
 	"os"
 	"strings"
 	"unsafe"
@@ -219,7 +218,7 @@ func NewFromBlob(blob []byte, extension string) (im *MagickImage, err error) {
 	image := C.ReadImageFromBlob(info, blob_start, length)
 
 	if image == nil {
-		return nil, errors.New("CORRUPT IMAGE")
+		return nil, &MagickError{"fatal", "", "corrupt image, not a " + extension}
 	}
 
 	if failed := C.CheckException(exception); failed == C.MagickTrue {


### PR DESCRIPTION
Checks for the image being nil after the read, returns corrupt error if so.
